### PR TITLE
Fix more info links in academy

### DIFF
--- a/site/coaching-programs.html
+++ b/site/coaching-programs.html
@@ -349,7 +349,7 @@
             
               <div class="e-course-controls">
                 
-                  <a class="e-button" href="bringing-tech-innovation-to-procurement-and-the-government-supply-chain-detail.html">More Info</a>
+                  <a class="e-button" href="tech-innovation-in-procurement-detail.html">More Info</a>
                 
               </div>
             

--- a/templates/coaching-programs.html
+++ b/templates/coaching-programs.html
@@ -97,7 +97,7 @@
             {% if course.actions %}
               <div class="e-course-controls">
                 {% for button in course.actions %}
-                  <a class="e-button" href="{{button.link}}">{{button.label}}</a>
+                  <a class="e-button" href="{{course.name | slug + "-detail.html"}}">More Info</a>
                 {% endfor %}
               </div>
             {% endif %}
@@ -163,7 +163,7 @@
             {% if course.actions %}
               <div class="e-course-controls">
                 {% for button in course.actions %}
-                  <a class="e-button" href="{{button.link}}">{{button.label}}</a>
+                  <a class="e-button" href="{{course.name | slug + "-detail.html"}}">More Info</a>
                 {% endfor %}
               </div>
             {% endif %}


### PR DESCRIPTION
Also fixes #6  finally. Instead of relying on the hardcoded slug to direct to the coaching details page, we slugged it with nunjucks.
